### PR TITLE
fix: change img to startingpoint in verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,6 @@ Check the [just website](https://just.systems) for tips on modifying and adding 
 
 These images are signed with sisgstore's [cosign](https://docs.sigstore.dev/cosign/overview/). You can verify the signature by downloading the `cosign.pub` key from this repo and running the following command:
 
-    cosign verify --key cosign.pub ghcr.io/ublue-os/base
+    cosign verify --key cosign.pub ghcr.io/ublue-os/startingpoint
 
 If you're forking this repo, the uBlue website has [instructions](https://ublue.it/making-your-own/) for setting up signing properly.


### PR DESCRIPTION
this makes it so that the create-ublue-script automatically replaces it