### PR TITLE
fix: update cosign installer version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -156,7 +156,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       # Sign container
-      - uses: sigstore/cosign-installer@v3.0.1
+      - uses: sigstore/cosign-installer@v3.0.2
         if: github.event_name != 'pull_request'
 
       - name: Sign container image


### PR DESCRIPTION
i hear there's problems with 3.0.1 that are fixed in 3.0.2 that can affect people using this repository as a template