### PR TITLE
feat: add per-recipe shell script support

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -8,6 +8,11 @@ ARG RECIPE
 COPY etc /etc
 # COPY usr /usr
 
+# copy scripts
+RUN mkdir /tmp/scripts
+COPY scripts /tmp/scripts
+RUN find /tmp/scripts -type f -exec chmod +x {} \;
+
 COPY ${RECIPE} /tmp/ublue-recipe.yml
 
 # yq used in build.sh and the setup-flatpaks recipe to read the recipe.yml

--- a/build.sh
+++ b/build.sh
@@ -1,4 +1,13 @@
 #!/bin/bash
+# run scripts
+echo "-- Running scripts defined in recipe.yml --"
+buildscripts=$(yq '.scripts[]' < /tmp/ublue-recipe.yml)
+for script in $(echo -e "$buildscripts"); do \
+    echo "Running: ${script}" && \
+    /tmp/scripts/$script; \
+done
+echo "---"
+
 # remove the default firefox (from fedora) in favor of the flatpak
 rpm-ostree override remove firefox firefox-langpacks
 

--- a/recipe.yml
+++ b/recipe.yml
@@ -15,6 +15,11 @@ fedora-version: 37
 # This description will be visible in the container metadata
 description: A starting point for further customization of uBlue images. Make your own! https://ublue.it/making-your-own/
 
+# These scripts will be executed during the container build
+# Place scripts in scripts/ and put the corresponding filename here
+scripts:
+#  - example.sh
+
 # These rpms will be installed from the fedora repository
 # using rpm-ostree and will be preinstalled in the final image
 rpms:

--- a/scripts/example.sh
+++ b/scripts/example.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+echo 'This is an example shell script'
+echo 'Scripts here will run during build if specified in recipe.yml'


### PR DESCRIPTION
Adds support for running shell scripts during build as specified in the `recipe.yml` file, which allows for different scripts to be executed on different recipes within a single repository.

Scripts are kept in the `scripts` directory, and can be specified by filename in the `scripts` section of `recipe.yml`.
I have included `example.sh` to help show users how to add a script to their recipe.

Love the project, keep up the good work!