### PR TITLE
fix!: move firstboot reference to new yafti.yml location

### DIFF
--- a/etc/skel.d/.config/autostart/ublue-firstboot.desktop
+++ b/etc/skel.d/.config/autostart/ublue-firstboot.desktop
@@ -1,7 +1,7 @@
 [Desktop Entry]
 Name=uBlue First Boot Setup
 Comment=Sets up uBlue Desktop Correctly On FirstBoot
-Exec=/usr/bin/yafti /usr/etc/yafti.yml
+Exec=/usr/bin/yafti /usr/share/ublue-os/firstboot/yafti.yml
 Icon=org.gnome.Terminal
 Type=Application
 Categories=Utility;System;


### PR DESCRIPTION
This hidden file was missed due to ripgrep's default "skip dotfiles" rule. All previous moves have also been re-analyzed with ripgrep again to ensure that nothing else was missed.

**For future reference,** anyone who needs to search in this repo should use `rg --hidden` to ensure that you also scan the hidden files! ;)