### PR TITLE
fix!: optimize container layers and reduce image size

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -13,24 +13,18 @@ ARG RECIPE
 # See issue #28 (https://github.com/ublue-os/startingpoint/issues/28).
 COPY usr /usr
 
-# Copy recipe.
+# Copy the recipe that we're building.
 COPY ${RECIPE} /usr/share/ublue-os/recipe.yml
 
-# "yq" used in build.sh and the setup-flatpaks recipe to read the recipe.yml.
+# "yq" used in build.sh and the "setup-flatpaks" just-action to read recipe.yml.
 # Copied from the official container image since it's not available as an RPM.
 COPY --from=docker.io/mikefarah/yq /usr/bin/yq /usr/bin/yq
 
-# Copy scripts.
-RUN mkdir /tmp/scripts
+# Copy the build script and all custom scripts.
 COPY scripts /tmp/scripts
-RUN find /tmp/scripts -type f -exec chmod +x {} \;
 
-# Copy and run the build script.
-COPY build.sh /tmp/build.sh
-RUN chmod +x /tmp/build.sh && /tmp/build.sh
-
-# Clean up and finalize container build.
-RUN rm -rf \
-        /tmp/* \
-        /var/* && \
-    ostree container commit
+# Run the build script, then clean up temp files and finalize container build.
+RUN chmod +x /tmp/scripts/build.sh && \
+        /tmp/scripts/build.sh && \
+        rm -rf /tmp/* /var/* && \
+        ostree container commit

--- a/README.md
+++ b/README.md
@@ -31,9 +31,9 @@ If you want to add custom configuration files, you can just add them in the `usr
 
 ### Custom build scripts
 
-If you want to execute custom shell scripts or commands in the image build, you shouldn't edit `build.sh` or the `Containerfile` directly.
+If you want to execute custom shell scripts or commands in the image build, you shouldn't edit the `scripts/build.sh` or the `Containerfile` directly.
 
-Instead, you can create shell scripts in the `scripts/` directory (look at the `example.sh`). After creating your scripts, enable them in the `scripts:` section of your `recipe.yml`, within the specific "build stage" category where the scripts are intended to be executed.
+Instead, you should create your own custom shell scripts in the `scripts/` directory (look at the `example.sh`). After creating your scripts, enable them in the `scripts:` section of your `recipe.yml`, within the specific "build stage" category where the scripts are intended to be executed. Alternatively, enable the `autorun.sh` helper script in your recipe to automatically execute your custom scripts.
 
 Read [the README in the `scripts/` directory](https://github.com/ublue-os/startingpoint/blob/main/scripts/README.md) for more information.
 

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -33,6 +33,9 @@ if [[ ${#repos[@]} -gt 0 ]]; then
     echo "---"
 fi
 
+# Ensure that all script files are executable.
+find /tmp/scripts -type f -exec chmod +x {} \;
+
 # Run "pre" scripts.
 run_scripts() {
     script_mode="$1"


### PR DESCRIPTION
Every individual RUN, COPY and ADD action creates an extra container layer, so there was plenty of room for improvement in our Containerfile.

This optimization gets rid of 4 useless layers from our final container image, and shrinks the final OCI download size as follows:

- Removing the "mkdir /tmp/scripts" layer. It's not necessary to manually create the target directory for the container copy action.

- Removing the manual "chmod +x" for the scripts, and putting that step inside "build.sh" instead.

- Removing the manual copying of "build.sh", by instead placing it at "scripts/build.sh" so that it's automatically copied together with all the other scripts in one layer instead.

- Removing the separate "chmod +x build.sh && run build script" step by merging it with the "cleanup temp files and then finalize the container" step, so that we don't create a pointless extra filesystem layer just for the build.sh script execution.

These changes also reduce the size of the final image, because we're cleaning up the image in the exact same step that we run the "build.sh". If we didn't combine these steps, we'd still be keeping a useless extra layer with all the /tmp/ and /var/ junk files that were left over after the build.

Most seriously, the "/var/cache" folder contained copies of ALL RPM FILES that build.sh installed via "rpm-ostree install". This meant that we were generating a very big layer with a lot of junk data that shipped in the final image.

Our build now only generates 7 layers (instead of 11), and users will have a much smaller OCI download since we aren't shipping the cached RPM "build leftovers" or temp files via useless extra layers anymore.