### PR TITLE
feat: add support for image signing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -118,6 +118,14 @@ jobs:
             io.artifacthub.package.readme-url=https://raw.githubusercontent.com/ublue-os/startingpoint/main/README.md
             io.artifacthub.package.logo-url=https://avatars.githubusercontent.com/u/120078124?s=200&v=4
 
+      # Workaround bug where capital letters in your GitHub username make it impossible to push to GHCR.
+      # https://github.com/macbre/push-to-ghcr/issues/12
+      - name: Lowercase Registry
+        id: registry_case
+        uses: ASzc/change-string-case-action@v5
+        with:
+          string: ${{ env.IMAGE_REGISTRY }}
+
       # Build image using Buildah action
       - name: Build Image
         id: build_image
@@ -132,16 +140,9 @@ jobs:
             FEDORA_MAJOR_VERSION=${{ env.FEDORA_MAJOR_VERSION }}
             BASE_IMAGE_URL=${{ env.BASE_IMAGE_URL }}
             RECIPE=${{ matrix.recipe }}
+            IMAGE_REGISTRY=${{ steps.registry_case.outputs.lowercase }}
           labels: ${{ steps.meta.outputs.labels }}
           oci: false
-
-      # Workaround bug where capital letters in your GitHub username make it impossible to push to GHCR.
-      # https://github.com/macbre/push-to-ghcr/issues/12
-      - name: Lowercase Registry
-        id: registry_case
-        uses: ASzc/change-string-case-action@v5
-        with:
-          string: ${{ env.IMAGE_REGISTRY }}
 
       # Push the image to GHCR (Image Registry)
       - name: Push To GHCR

--- a/Containerfile
+++ b/Containerfile
@@ -23,6 +23,10 @@ ARG RECIPE=./recipe.yml
 # for manual overrides and editing by the machine's admin AFTER installation!
 # See issue #28 (https://github.com/ublue-os/startingpoint/issues/28).
 COPY usr /usr
+# Copy public key
+COPY ./cosign.pub /usr/etc/pki/containers/cosign.pub
+# Copy base signing config
+COPY ./usr/etc/containers /usr/etc/
 
 # Copy the recipe that we're building.
 COPY ${RECIPE} /usr/share/ublue-os/recipe.yml

--- a/Containerfile
+++ b/Containerfile
@@ -15,6 +15,9 @@ FROM ${BASE_IMAGE_URL}:${FEDORA_MAJOR_VERSION}
 # so that `podman build` should just work for many people.
 ARG RECIPE=./recipe.yml
 
+# The default image registry to write to policy.json and cosign.yaml
+ARG IMAGE_REGISTRY=ghcr.io/ublue-os
+
 # Copy static configurations and component files.
 # Warning: If you want to place anything in "/etc" of the final image, you MUST
 # place them in "./usr/etc" in your repo, so that they're written to "/usr/etc"
@@ -23,10 +26,11 @@ ARG RECIPE=./recipe.yml
 # for manual overrides and editing by the machine's admin AFTER installation!
 # See issue #28 (https://github.com/ublue-os/startingpoint/issues/28).
 COPY usr /usr
+
 # Copy public key
-COPY ./cosign.pub /usr/etc/pki/containers/cosign.pub
+COPY cosign.pub /usr/etc/pki/containers/cosign.pub
 # Copy base signing config
-COPY ./usr/etc/containers /usr/etc/
+COPY usr/etc/containers /usr/etc/
 
 # Copy the recipe that we're building.
 COPY ${RECIPE} /usr/share/ublue-os/recipe.yml

--- a/README.md
+++ b/README.md
@@ -92,9 +92,17 @@ To rebase an existing Silverblue/Kinoite installation to the latest build:
   ```
   sudo rpm-ostree rebase ostree-unverified-registry:ghcr.io/ublue-os/startingpoint:latest
   ```
+- Reboot to complete the rebase:
+  ```
+  systemctl reboot
+  ```
 - Then rebase to the signed image, like so:
   ```
   sudo rpm-ostree rebase ostree-image-signed:docker://ghcr.io/ublue-os/startingpoint:latest
+  ```
+- Reboot again to complete the installation
+  ```
+  systemctl reboot
   ```
 
 

--- a/README.md
+++ b/README.md
@@ -88,15 +88,23 @@ If you want to completely disable yafti, simply set the recipe's `firstboot.yaft
 
 To rebase an existing Silverblue/Kinoite installation to the latest build:
 
-```
-sudo rpm-ostree rebase ostree-unverified-registry:ghcr.io/ublue-os/startingpoint:latest
-```
+- First rebase to the image unsigned, to get the proper signing keys and policies installed:
+  ```
+  sudo rpm-ostree rebase ostree-unverified-registry:ghcr.io/ublue-os/startingpoint:latest
+  ```
+- Then rebase to the signed image, like so:
+  ```
+  sudo rpm-ostree rebase ostree-image-signed:docker://ghcr.io/ublue-os/startingpoint:latest
+  ```
+
 
 This repository builds date tags as well, so if you want to rebase to a particular day's build:
 
 ```
-sudo rpm-ostree rebase ostree-unverified-registry:ghcr.io/ublue-os/startingpoint:20230403
+sudo rpm-ostree rebase ostree-image-signed:docker://ghcr.io/ublue-os/startingpoint:20230403
 ```
+
+This repository by default also supports signing 
 
 The `latest` tag will automatically point to the latest build. That build will still always use the Fedora version specified in `recipe.yml`, so you won't get accidentally updated to the next major version.
 

--- a/README.md
+++ b/README.md
@@ -147,10 +147,3 @@ After doing that, you'll be able to run the following commands:
 
 Check the [just website](https://just.systems) for tips on modifying and adding your own recipes.
 
-## Verification
-
-These images are signed with sisgstore's [cosign](https://docs.sigstore.dev/cosign/overview/). You can verify the signature by downloading the `cosign.pub` key from this repo and running the following command:
-
-    cosign verify --key cosign.pub ghcr.io/ublue-os/startingpoint
-
-If you're forking this repo, the uBlue website has [instructions](https://universal-blue.org/tinker/make-your-own/) for setting up signing properly.

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -24,6 +24,7 @@ echo "Building custom Fedora ${FEDORA_VERSION} from image: \"${BASE_IMAGE}\"."
 
 # Setup container signing
 echo "Setup container signing in policy.json and cosign.yaml"
+echo "Registry to write: $IMAGE_REGISTRY"
 sed -i "s ghcr.io/ublue-os $IMAGE_REGISTRY g" /usr/etc/containers/policy.json
 sed -i "s ghcr.io/ublue-os $IMAGE_REGISTRY g" /usr/etc/containers/registries.d/cosign.yaml
 

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -22,6 +22,11 @@ YAFTI_ENABLED="$(get_yaml_string '.firstboot.yafti')"
 # Welcome.
 echo "Building custom Fedora ${FEDORA_VERSION} from image: \"${BASE_IMAGE}\"."
 
+# Setup container signing
+echo "Setup container signing in policy.json and cosign.yaml"
+sed -i "s ghcr.io/ublue-os $IMAGE_REGISTRY g" /usr/etc/containers/policy.json
+sed -i "s ghcr.io/ublue-os $IMAGE_REGISTRY g" /usr/etc/containers/registries.d/cosign.yaml
+
 # Add custom repos.
 get_yaml_array repos '.rpm.repos[]'
 if [[ ${#repos[@]} -gt 0 ]]; then

--- a/usr/etc/containers/policy.json
+++ b/usr/etc/containers/policy.json
@@ -1,0 +1,74 @@
+{
+    "default": [
+        {
+            "type": "reject"
+        }
+    ],
+    "transports": {
+        "docker": {
+            "registry.access.redhat.com": [
+                {
+                    "type": "signedBy",
+                    "keyType": "GPGKeys",
+                    "keyPath": "/etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release"
+                }
+            ],
+            "registry.redhat.io": [
+                {
+                    "type": "signedBy",
+                    "keyType": "GPGKeys",
+                    "keyPath": "/etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release"
+                }
+            ],
+            "ghcr.io/ublue-os": [
+                {
+                    "type": "sigstoreSigned",
+                    "keyPath": "/usr/etc/pki/containers/cosign.pub",
+                    "signedIdentity": {
+                        "type": "matchRepository"
+                    }
+                }
+            ],
+            "": [
+                {
+                    "type": "insecureAcceptAnything"
+                }
+            ]
+        },
+        "docker-daemon": {
+            "": [
+                {
+                    "type": "insecureAcceptAnything"
+                }
+            ]
+        },
+        "atomic": {
+            "": [
+                {
+                    "type": "insecureAcceptAnything"
+                }
+            ]
+        },
+        "dir": {
+            "": [
+                {
+                    "type": "insecureAcceptAnything"
+                }
+            ]
+        },
+        "oci": {
+            "": [
+                {
+                    "type": "insecureAcceptAnything"
+                }
+            ]
+        },
+        "tarball": {
+            "": [
+                {
+                    "type": "insecureAcceptAnything"
+                }
+            ]
+        }
+    }
+}

--- a/usr/etc/containers/registries.d/cosign.yaml
+++ b/usr/etc/containers/registries.d/cosign.yaml
@@ -1,0 +1,3 @@
+docker:
+  ghcr.io/ublue-os:
+    use-sigstore-attachments: true


### PR DESCRIPTION
This PR adds image signing, with no additional configuration required from the user
Things done:
- copy cosign public key and policy.json in the proper place (`/etc/pki/containers/cosign.pub` and `/etc/containers/policy.json`)
- automatically fill in repo details in `/etc/containers/policy.json` and `/etc/containers/registries.d/cosign.yaml` in the build script

Things that still need to be done:
- properly document container signing in the README
- test!