### PR TITLE
Updating Gamescope to pull from the most recent package.

### DIFF
--- a/usr/share/ublue-os/firstboot/yafti.yml
+++ b/usr/share/ublue-os/firstboot/yafti.yml
@@ -103,7 +103,7 @@ screens:
             - GNOME Games: org.gnome.Games
             - Heroic Games Launcher: com.heroicgameslauncher.hgl
             - Steam: com.valvesoftware.Steam
-            - Gamescope (Utility): com.valvesoftware.Steam.Utility.gamescope
+            - Gamescope (Utility): org.freedesktop.Platform.VulkanLayer.gamescope
             - MangoHUD (Utility): org.freedesktop.Platform.VulkanLayer.MangoHud//22.08
             - SteamTinkerLaunch (Utility): com.valvesoftware.Steam.Utility.steamtinkerlaunch
             - Proton Updater for Steam: net.davidotek.pupgui2

--- a/usr/share/ublue-os/firstboot/yafti.yml
+++ b/usr/share/ublue-os/firstboot/yafti.yml
@@ -100,7 +100,6 @@ screens:
           packages:
             - Bottles: com.usebottles.bottles
             - Discord: com.discordapp.Discord
-            - GNOME Games: org.gnome.Games
             - Heroic Games Launcher: com.heroicgameslauncher.hgl
             - Steam: com.valvesoftware.Steam
             - Gamescope (Utility): org.freedesktop.Platform.VulkanLayer.gamescope

--- a/usr/share/ublue-os/firstboot/yafti.yml
+++ b/usr/share/ublue-os/firstboot/yafti.yml
@@ -100,6 +100,7 @@ screens:
           packages:
             - Bottles: com.usebottles.bottles
             - Discord: com.discordapp.Discord
+            - GNOME Games: org.gnome.Games
             - Heroic Games Launcher: com.heroicgameslauncher.hgl
             - Steam: com.valvesoftware.Steam
             - Gamescope (Utility): org.freedesktop.Platform.VulkanLayer.gamescope


### PR DESCRIPTION
per the flatpak updating utility, the valve version of this is "end of life" and is now being maintained with the new package.