### PR TITLE
org.gnome.games appears to be dead

### DIFF
--- a/usr/share/ublue-os/firstboot/yafti.yml
+++ b/usr/share/ublue-os/firstboot/yafti.yml
@@ -100,7 +100,6 @@ screens:
           packages:
             - Bottles: com.usebottles.bottles
             - Discord: com.discordapp.Discord
-            - GNOME Games: org.gnome.Games
             - Heroic Games Launcher: com.heroicgameslauncher.hgl
             - Steam: com.valvesoftware.Steam
             - Gamescope (Utility): org.freedesktop.Platform.VulkanLayer.gamescope


### PR DESCRIPTION
Per just update, gnome.gnome.games appears to be deprecated, and googling appears to show no real replacement at this time. 