### PR TITLE
fix: removed issues in rpm-ostree module and ublue-update bling installer 

### DIFF
--- a/modules/bling/installers/ublue-update.sh
+++ b/modules/bling/installers/ublue-update.sh
@@ -7,4 +7,14 @@ set -oue pipefail
 if rpm -q ublue-os-update-services > /dev/null; then
     rpm-ostree override remove ublue-os-update-services
 fi
+
+# Change the conflicting update policy for rpm-ostreed
+RPM_OSTREE_CONFIG="/usr/etc/rpm-ostreed.conf"
+
+if [[ -f $RPM_OSTREE_CONFIG ]]; then
+    if [[ "$(get_config_value AutomaticUpdatePolicy $RPM_OSTREE_CONFIG)" == "stage" ]]; then
+        set_config_value AutomaticUpdatePolicy none $RPM_OSTREE_CONFIG
+    fi
+fi
+
 rpm-ostree install "$BLING_DIRECTORY"/rpms/ublue-update*.rpm

--- a/modules/rpm-ostree/rpm-ostree.sh
+++ b/modules/rpm-ostree/rpm-ostree.sh
@@ -24,6 +24,7 @@ if [[ ${#OPTFIX[@]} -gt 0 ]]; then
     for OPTPKG in "${OPTFIX[@]}"; do
         OPTPKG="${OPTPKG%\"}"
         OPTPKG="${OPTPKG#\"}"
+        OPTPKG=$(printf "$OPTPKG")
         mkdir -p "/usr/lib/opt/${OPTPKG}"
         ln -s "../../usr/lib/opt/${OPTPKG}" "/var/opt/${OPTPKG}"
         echo "Created symlinks for ${OPTPKG}"


### PR DESCRIPTION
This fixes optfix and makes the symlink not broken