### PR TITLE
fix(build.sh): export `get_config_value` and `set_config_value` to make ublue-update installer work

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -14,10 +14,22 @@ MODULE_DIRECTORY="/tmp/modules"
 
 # https://mikefarah.gitbook.io/yq/usage/tips-and-tricks#yq-in-a-bash-loop
 get_yaml_array() {
-    # creates array $1 with content at key $2 from $3 
+    # creates array $1 with content at key $2 from $3
     readarray "$1" < <(echo "$3" | yq -I=0 "$2")
 }
+
+get_config_value() {
+    sed -n '/^'"$1"'=/{s/'"$1"'=//;p}'
+}
+
+set_config_value() {
+    CURRENT=$(get_config_value $1 $3)
+    sed -i 's/'"$1"'='"$CURRENT"'/'"$1"'='"$2"'/g' $3
+}
+
 export -f get_yaml_array # this makes the function available to all modules
+export -f get_config_value
+export -f set_config_value
 
 # Declare dynamically generated variables as exported
 declare -x IMAGE_NAME BASE_IMAGE OS_VERSION


### PR DESCRIPTION
Dunno why the functions got deleted in the script, saw get_config_value was there, but wasn't exported, just fixed it up real quick. Noticed the issue when automatic updates with rpm-ostreed were still enabled when using the bling module to install ublue-update