### PR TITLE
feat: create /usr/share/ublue-os/image-info.json inside signing.sh

### DIFF
--- a/config/scripts/signing.sh
+++ b/config/scripts/signing.sh
@@ -24,9 +24,7 @@ yq -i -o=j '.transports.docker |=
 + .' "$FILE"
 
 IMAGE_REF="ostree-image-signed:docker://$IMAGE_REGISTRY/$IMAGE_NAME"
-
-printf '{\n"image-ref": "'"$IMAGE_REF"'",\n"image-default-tag":"latest"\n}' > /usr/share/ublue-os/image-info.json
-cat /usr/share/ublue-os/image-info.json
+printf '{\n"image-ref": "'"$IMAGE_REF"'",\n"image-default-tag": "latest"\n}' > /usr/share/ublue-os/image-info.json
 
 cp /usr/etc/containers/registries.d/ublue-os.yaml /usr/etc/containers/registries.d/"$IMAGE_NAME".yaml
 sed -i "s ghcr.io/ublue-os $IMAGE_REGISTRY g" /usr/etc/containers/registries.d/"$IMAGE_NAME".yaml

--- a/config/scripts/signing.sh
+++ b/config/scripts/signing.sh
@@ -10,7 +10,7 @@ cp /usr/share/ublue-os/cosign.pub /usr/etc/pki/containers/"$IMAGE_NAME".pub
 
 FILE=/usr/etc/containers/policy.json
 
-yq -i -o=j '.transports.docker |= 
+yq -i -o=j '.transports.docker |=
     {"'"$IMAGE_REGISTRY"'": [
             {
                 "type": "sigstoreSigned",
@@ -22,6 +22,11 @@ yq -i -o=j '.transports.docker |=
         ]
     }
 + .' "$FILE"
+
+IMAGE_REF="ostree-image-signed:docker://$IMAGE_REGISTRY/$IMAGE_NAME"
+
+printf '{\n"image-ref": "'"$IMAGE_REF"'",\n"image-default-tag":"latest"\n}' > /usr/share/ublue-os/image-info.json
+cat /usr/share/ublue-os/image-info.json
 
 cp /usr/etc/containers/registries.d/ublue-os.yaml /usr/etc/containers/registries.d/"$IMAGE_NAME".yaml
 sed -i "s ghcr.io/ublue-os $IMAGE_REGISTRY g" /usr/etc/containers/registries.d/"$IMAGE_NAME".yaml


### PR DESCRIPTION
corresponds with: https://github.com/ublue-os/ublue-update/pull/73
doesn't break compat, just adds the ability for `ublue-update` to automatically rebase/sign the image by default, which makes dealing with offline ISOs much easier