### PR TITLE
feat(yafti): use newest GNOME Camera and Image Viewer

### DIFF
--- a/config/files/usr/share/ublue-os/firstboot/yafti.yml
+++ b/config/files/usr/share/ublue-os/firstboot/yafti.yml
@@ -59,8 +59,8 @@ screens:
           packages:
             - Calculator: org.gnome.Calculator
             - Calendar: org.gnome.Calendar
+            - Camera: org.gnome.Snapshot
             - Characters: org.gnome.Characters
-            - Cheese: org.gnome.Cheese
             - Clocks: org.gnome.clocks
             - Connections: org.gnome.Connections
             - Contacts: org.gnome.Contacts
@@ -69,7 +69,7 @@ screens:
             - Document Viewer: org.gnome.Evince
             - Extension Manager: com.mattjakeman.ExtensionManager
             - Font Viewer: org.gnome.font-viewer
-            - Image Viewer: org.gnome.eog
+            - Image Viewer: org.gnome.Loupe
             - Logs: org.gnome.Logs
             - Maps: org.gnome.Maps
             - Photos (Organizer): org.gnome.Photos


### PR DESCRIPTION
Makes `yafti` install the newest [GNOME Camera](https://flathub.org/apps/org.gnome.Snapshot) and [Image Viewer](https://flathub.org/apps/org.gnome.Loupe) instead of Cheese and Eye of GNOME. These apps are the new defaults starting on GNOME 45.