### PR TITLE
feat(yafti): add GNOME Web to the `Web Browsers` section

### DIFF
--- a/config/files/usr/share/ublue-os/firstboot/yafti.yml
+++ b/config/files/usr/share/ublue-os/firstboot/yafti.yml
@@ -91,6 +91,7 @@ screens:
           default: false
           packages:
             - Brave: com.brave.Browser
+            - GNOME Web: org.gnome.Epiphany
             - Google Chrome: com.google.Chrome
             - Microsoft Edge: com.microsoft.Edge
             - Opera: com.opera.Opera


### PR DESCRIPTION
[GNOME Web](https://flathub.org/apps/org.gnome.Epiphany) will be added on `yafti`'s list of web browsers.