### PR TITLE
fix: remove image-info.json from base image if it exists

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -63,6 +63,8 @@ OS_VERSION="$(grep -Po '(?<=VERSION_ID=)\d+' /usr/lib/os-release)"
 echo "Building $IMAGE_NAME from $BASE_IMAGE:$OS_VERSION."
 
 # Remove old image-info.json from main image
+# (this file is added back by signing.sh, but shouldn't exist
+# with wrong details in an unsigned image)
 IMAGE_INFO="/usr/share/ublue-os/image-info.json"
 if [ -f "$IMAGE_INFO" ]; then
     rm -v "$IMAGE_INFO"

--- a/build.sh
+++ b/build.sh
@@ -62,4 +62,10 @@ OS_VERSION="$(grep -Po '(?<=VERSION_ID=)\d+' /usr/lib/os-release)"
 # Welcome.
 echo "Building $IMAGE_NAME from $BASE_IMAGE:$OS_VERSION."
 
+# Remove old image-info.json from main image
+IMAGE_INFO="/usr/share/ublue-os/image-info.json"
+if [ -f "$IMAGE_INFO" ]; then
+    rm -v "$IMAGE_INFO"
+fi
+
 run_modules "$RECIPE_FILE"


### PR DESCRIPTION
if the user forgets to run the signing script and somehow installs `ublue-update`, `ublue-update` won't try to rebase them to the base image they chose. 