### PR TITLE
fix: specify image name in policy.json

### DIFF
--- a/config/scripts/signing.sh
+++ b/config/scripts/signing.sh
@@ -11,7 +11,7 @@ cp /usr/share/ublue-os/cosign.pub /usr/etc/pki/containers/"$IMAGE_NAME".pub
 FILE=/usr/etc/containers/policy.json
 
 yq -i -o=j '.transports.docker |=
-    {"'"$IMAGE_REGISTRY"'": [
+    {"'"$IMAGE_REGISTRY"'/'"$IMAGE_NAME"'": [
             {
                 "type": "sigstoreSigned",
                 "keyPath": "/usr/etc/pki/containers/'"$IMAGE_NAME"'.pub",


### PR DESCRIPTION
There was talk on the discord about not being able to pull in images with podman because the signing policy included *every* image inside of the user's ghcr account. Which means that images not signed with the same key won't be able to be pulled down. This solves that issue by specifying the custom image in the policy