### PR TITLE
chore: update bling list

### DIFF
--- a/config/recipe.yml
+++ b/config/recipe.yml
@@ -32,13 +32,18 @@ modules:
 
   - type: bling # configure what to pull in from ublue-os/bling
     install:
-      - justfiles # add "!include /usr/share/ublue-os/just/bling.just"
+      - justfiles # add "!include /usr/share/ublue-os/just/100-bling.just"
                   # in your custom.just (added by default) or local justfile
-      - nix-installer # shell shortcuts for determinate system's nix installers
+      - nix-installer # these are the silverblue nix installer scripts from dnkmmr69420
       - ublue-os-wallpapers
       # - ublue-update # https://github.com/ublue-os/ublue-update
+      # - 1password # 1Password (stable) and `op` CLI tool installed on base image
       # - dconf-update-service # a service unit that updates the dconf db on boot
       # - devpod # https://devpod.sh/ as an rpm
+      # - gnome-vrr # enables gnome-vrr for your image
+      # - container-tools # installs container-related tools onto /usr/bin: kind, kubectx, docker-compose and kubens
+      # - laptop # installs TLP and configures your system for laptop usage
+      # - flatpaksync # allows synchronization of user-installed flatpaks, see separate documentation section
 
 
   - type: yafti # if included, yafti and it's dependencies (pip & libadwaita)

--- a/config/recipe.yml
+++ b/config/recipe.yml
@@ -34,10 +34,10 @@ modules:
     install:
       - justfiles # add "!include /usr/share/ublue-os/just/100-bling.just"
                   # in your custom.just (added by default) or local justfile
-      - nix-installer # these are the silverblue nix installer scripts from dnkmmr69420
+      - nix-installer # shell shortcuts for determinate system's nix installers
       - ublue-os-wallpapers
       # - ublue-update # https://github.com/ublue-os/ublue-update
-      # - 1password # 1Password (stable) and `op` CLI tool installed on base image
+      # - 1password # install 1Password (stable) and `op` CLI tool
       # - dconf-update-service # a service unit that updates the dconf db on boot
       # - devpod # https://devpod.sh/ as an rpm
       # - gnome-vrr # enables gnome-vrr for your image


### PR DESCRIPTION
Such that startingpoint users directly get on overview of the available bling without looking into the bling repository.