### PR TITLE
feat: Indicate support for hidden just scripts

### DIFF
--- a/config/files/usr/share/ublue-os/just/60-custom.just
+++ b/config/files/usr/share/ublue-os/just/60-custom.just
@@ -2,14 +2,14 @@
 
 ### Useful features ###
 #
-# Hide just script from "just" prompt, but make it still available by using [private] string above the just script name.
-# Documentation: https://just.systems/man/en/chapter_49.html?highlight=private#private-recipes
+# 1. Hide just script from "just" prompt, but make it still available by using [private] string above the just script name.
+#     Documentation: https://just.systems/man/en/chapter_49.html?highlight=private#private-recipes
 #
-# Example (ignore starting # symbol):
+#     Example (ignore starting # symbol):
 #
-# [private]
-# private-script:
-# #!/usr/bin/env bash
-# echo "Hello world!"
+#     [private]
+#     private-script:
+#     #!/usr/bin/env bash
+#     echo "Hello world!"
 
 # Include some of your custom scripts here!

--- a/config/files/usr/share/ublue-os/just/60-custom.just
+++ b/config/files/usr/share/ublue-os/just/60-custom.just
@@ -1,4 +1,15 @@
 !include /usr/share/ublue-os/just/100-bling.just
 
-# Include some of your custom scripts here!
+### Useful features ###
+#
 # Hide just script from "just" prompt, but make it still available by using [private] string above the just script name.
+# Documentation: https://just.systems/man/en/chapter_49.html?highlight=private#private-recipes
+#
+# Example (ignore starting # symbol):
+#
+# [private]
+# private-script:
+# #!/usr/bin/env bash
+# echo "Hello world!"
+
+# Include some of your custom scripts here!

--- a/config/files/usr/share/ublue-os/just/60-custom.just
+++ b/config/files/usr/share/ublue-os/just/60-custom.just
@@ -1,3 +1,4 @@
 !include /usr/share/ublue-os/just/100-bling.just
 
 # Include some of your custom scripts here!
+# Hide just script from "just" prompt, but make it still available by using [private] string above the just script name.

--- a/config/files/usr/share/ublue-os/just/60-custom.just
+++ b/config/files/usr/share/ublue-os/just/60-custom.just
@@ -5,7 +5,7 @@
 # 1. Hide just script from "just" prompt, but make it still available by using [private] string above the just script name.
 #       Documentation: https://just.systems/man/en/chapter_49.html?highlight=private#private-recipes
 #
-#       Example (ignore starting # symbol):
+#       Example:
 #
 #       [private]
 #       private-script:

--- a/config/files/usr/share/ublue-os/just/60-custom.just
+++ b/config/files/usr/share/ublue-os/just/60-custom.just
@@ -3,13 +3,13 @@
 ### Useful features ###
 #
 # 1. Hide just script from "just" prompt, but make it still available by using [private] string above the just script name.
-#     Documentation: https://just.systems/man/en/chapter_49.html?highlight=private#private-recipes
+#       Documentation: https://just.systems/man/en/chapter_49.html?highlight=private#private-recipes
 #
-#     Example (ignore starting # symbol):
+#       Example (ignore starting # symbol):
 #
-#     [private]
-#     private-script:
-#     #!/usr/bin/env bash
-#     echo "Hello world!"
+#       [private]
+#       private-script:
+#       #!/usr/bin/env bash
+#       echo "Hello world!"
 
 # Include some of your custom scripts here!


### PR DESCRIPTION
This is useful if you want to incorporate some placeholder or post-setup just scripts in yafti that you don't want to expose to end-users.