### PR TITLE
fix: use -R flag to select repo on iso-deleting `gh` commands

### DIFF
--- a/.github/workflows/release-iso.yml
+++ b/.github/workflows/release-iso.yml
@@ -35,7 +35,7 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
         run: |
           if gh release list -R ${{ github.repository_owner }}/${{ github.event.repository.name }} | grep "auto-iso"; then
-            gh release view auto-iso --json assets -q .assets[].name | xargs -L 1 gh release delete-asset auto-iso 
+            gh release view auto-iso -R ${{ github.repository_owner }}/${{ github.event.repository.name }} --json assets -q .assets[].name | xargs -L 1 gh release delete-asset auto-iso -R ${{ github.repository_owner }}/${{ github.event.repository.name }}
             gh release upload auto-iso ${{ steps.isogenerator.outputs.iso-path }} -R ${{ github.repository_owner }}/${{ github.event.repository.name }} --clobber
           else
             gh release create auto-iso ${{ steps.isogenerator.outputs.iso-path }} -t ISO -n "This is an automatically generated ISO release." -R ${{ github.repository_owner }}/${{ github.event.repository.name }}


### PR DESCRIPTION
https://github.com/ublue-os/startingpoint/pull/185#issuecomment-1819431438
@EyeCantCU @fiftydinar