### PR TITLE
fix: do not format just files in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,9 +54,6 @@ jobs:
       - name: Checkout Push to Registry action
         uses: actions/checkout@v4
 
-      - name: Check just syntax
-        uses: ublue-os/just-action@v1
-
       - name: Add yq (for reading recipe.yml)
         uses: mikefarah/yq@v4.40.4
 


### PR DESCRIPTION
The just syntax checker introduced in #194 breaks the CI build. The `--fmt` resolves the includes (see https://github.com/casey/just/issues/1585).

I do not understand why this doesn't happen in this repository but it fails for me in https://github.com/plata/ublue-surface/pull/48.

fixes #204