### PR TITLE
POC Template Containerfile using Ublue CLI Tool

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,11 +45,11 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Run a Command
+      - name: Template Containerfile
         run: |
           ublue template -vv ./config/${{ matrix.recipe }} -o Containerfile
 
-      - name: Upload Artifact
+      - name: Upload Containerfile
         uses: actions/upload-artifact@v2
         with:
           name: containerfile

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,7 +47,7 @@ jobs:
 
       - name: Run a Command
         run: |
-          ublue template ./config/${{ matrix.recipe }} -o Containerfile
+          ublue template -vv ./config/${{ matrix.recipe }} -o Containerfile
 
       - name: Upload Artifact
         uses: actions/upload-artifact@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,19 +18,16 @@ on: # https://docs.github.com/en/actions/using-workflows/events-that-trigger-wor
   pull_request:
   workflow_dispatch:
 
-env:
-  IMAGE_REGISTRY: ghcr.io/${{ github.repository_owner }}
-
 # Only deploys the branch named "live". Ignores all other branches, to allow
 # having "development" branches without interfering with GHCR image uploads.
 jobs:
-  template:
+  ublue-build:
     name: Template Containerfile
     runs-on: ubuntu-22.04
     permissions:
       contents: read
     container:
-      image: registry.gitlab.com/wunker-bunker/ublue-cli:alpine
+      image: registry.gitlab.com/wunker-bunker/ublue-cli:0.3.5-test-alpine
     strategy:
       fail-fast: false
 
@@ -46,206 +43,10 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Template Containerfile
-        run: |
-          ublue template -vv ./config/${{ matrix.recipe }} -o Containerfile
-
-      - name: Upload Containerfile
-        uses: actions/upload-artifact@v2
-        with:
-          name: containerfile
-          path: Containerfile
-  push-ghcr:
-    name: Build and push image
-    runs-on: ubuntu-22.04
-    needs: template
-    permissions:
-      contents: read
-      packages: write
-      id-token: write
-    strategy:
-      fail-fast: false
-
-      matrix:
-# !!!
-        # Add recipes for all the images you want to build here.
-        # Don't add module configuration files, you will get errors.
-        recipe:
-          - recipe.yml
-# !!!
-
-    steps:
-      - name: Maximize build space
-        uses: AdityaGarg8/remove-unwanted-software@v1
-        with:
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-
-      # Checkout push-to-registry action GitHub repository
-      - name: Checkout Push to Registry action
-        uses: actions/checkout@v4
-
-      # Confirm that cosign.pub matches SIGNING_SECRET
-      - uses: sigstore/cosign-installer@v3.3.0
-        if: github.event_name != 'pull_request' && github.ref == 'refs/heads/live'
-
-      - name: Check SIGNING_SECRET matches cosign.pub
-        if: github.event_name != 'pull_request' && github.ref == 'refs/heads/live'
         env:
-          COSIGN_EXPERIMENTAL: false
-          COSIGN_PASSWORD: ""
           COSIGN_PRIVATE_KEY: ${{ secrets.SIGNING_SECRET }}
-        shell: bash
         run: |
-          echo "Checking for difference between public key from SIGNING_SECRET and cosign.pub"
-          delta=$(diff -u <(cosign public-key --key env://COSIGN_PRIVATE_KEY) cosign.pub)
-          if [ -z "$delta" ]; then
-            echo "cosign.pub matches SIGNING_SECRET"
-          else
-            echo "cosign.pub does not match SIGNING_SECRET"
-            echo "$delta"
-            exit 1
-          fi
-
-      - name: Add yq (for reading recipe.yml)
-        uses: mikefarah/yq@v4.40.5
-
-      - name: Gather image data from recipe
-        run: |
-          echo "IMAGE_NAME=$(yq '.name' ./config/${{ matrix.recipe }})" >> $GITHUB_ENV
-          echo "IMAGE_DESCRIPTION=$(yq '.description' ./config/${{ matrix.recipe }})" >> $GITHUB_ENV
-          echo "IMAGE_MAJOR_VERSION=$(yq '.image-version' ./config/${{ matrix.recipe }})" >> $GITHUB_ENV
-          echo "BASE_IMAGE_URL=$(yq '.base-image' ./config/${{ matrix.recipe }})" >> $GITHUB_ENV
-
-      - name: Get current version
-        id: labels
-        run: |
-          ver=$(skopeo inspect docker://${{ env.BASE_IMAGE_URL }}:${{ env.IMAGE_MAJOR_VERSION }} | jq -r '.Labels["org.opencontainers.image.version"]')
-          echo "VERSION=$ver" >> $GITHUB_OUTPUT
-
-      - name: Generate tags
-        id: generate-tags
-        shell: bash
-        run: |
-          # Generate a timestamp for creating an image version history
-          TIMESTAMP="$(date +%Y%m%d)"
-          MAJOR_VERSION="$(echo ${{ steps.labels.outputs.VERSION }} | cut -d . -f 1)"
-          COMMIT_TAGS=()
-          BUILD_TAGS=()
-          # Have tags for tracking builds during pull request
-          SHA_SHORT="${GITHUB_SHA::7}"
-
-          # Using clever bash string templating, https://stackoverflow.com/q/40771781
-          # don't make malformed tags if $MAJOR_VERSION is empty (base-image didn't include proper labels) --
-          COMMIT_TAGS+=("pr-${{ github.event.number }}${MAJOR_VERSION:+-$MAJOR_VERSION}")
-          COMMIT_TAGS+=("${SHA_SHORT}${MAJOR_VERSION:+-$MAJOR_VERSION}")
-
-          BUILD_TAGS=("${MAJOR_VERSION}" "${MAJOR_VERSION:+$MAJOR_VERSION-}${TIMESTAMP}")
-          # --
-
-          BUILD_TAGS+=("${TIMESTAMP}")
-          BUILD_TAGS+=("latest")
-
-          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
-              echo "Generated the following commit tags: "
-              for TAG in "${COMMIT_TAGS[@]}"; do
-                  echo "${TAG}"
-              done
-              alias_tags=("${COMMIT_TAGS[@]}")
-          else
-              alias_tags=("${BUILD_TAGS[@]}")
-          fi
-          echo "Generated the following build tags: "
-          for TAG in "${BUILD_TAGS[@]}"; do
-              echo "${TAG}"
-          done
-          echo "alias_tags=${alias_tags[*]}" >> $GITHUB_OUTPUT
-
-      # Build metadata
-      - name: Image Metadata
-        uses: docker/metadata-action@v5
-        id: meta
-        with:
-          images: |
-            ${{ env.IMAGE_NAME }}
-          labels: |
-            org.opencontainers.image.title=${{ env.IMAGE_NAME }}
-            org.opencontainers.image.version=${{ steps.labels.outputs.VERSION }}
-            org.opencontainers.image.description=${{ env.IMAGE_DESCRIPTION }}
-            io.artifacthub.package.readme-url=https://raw.githubusercontent.com/ublue-os/startingpoint/main/README.md
-            io.artifacthub.package.logo-url=https://avatars.githubusercontent.com/u/120078124?s=200&v=4
-
-      # Workaround bug where capital letters in your GitHub username make it impossible to push to GHCR.
-      # https://github.com/macbre/push-to-ghcr/issues/12
-      - name: Lowercase Registry
-        id: registry_case
-        uses: ASzc/change-string-case-action@v6
-        with:
-          string: ${{ env.IMAGE_REGISTRY }}
-
-      - name: Lowercase Image
-        id: image_case
-        uses: ASzc/change-string-case-action@v6
-        with:
-          string: ${{ env.IMAGE_NAME }}
-
-      - name: Download Artifact
-        uses: actions/download-artifact@v2
-        with:
-          name: containerfile
-
-      # Build image using Buildah action
-      - name: Build Image
-        id: build_image
-        uses: redhat-actions/buildah-build@v2
-        with:
-          containerfiles: |
-            ./Containerfile
-          image: ${{ env.IMAGE_NAME }}
-          tags: |
-            ${{ steps.generate-tags.outputs.alias_tags }}
-          build-args: |
-            IMAGE_MAJOR_VERSION=${{ env.IMAGE_MAJOR_VERSION }}
-            BASE_IMAGE_URL=${{ env.BASE_IMAGE_URL }}
-            RECIPE=${{ matrix.recipe }}
-            IMAGE_REGISTRY=${{ steps.registry_case.outputs.lowercase }}
-          labels: ${{ steps.meta.outputs.labels }}
-          oci: false
-
-      # Push the image to GHCR (Image Registry)
-      - name: Push To GHCR
-        uses: redhat-actions/push-to-registry@v2
-        id: push
-        if: github.event_name != 'pull_request' && github.ref == 'refs/heads/live'
-        env:
-          REGISTRY_USER: ${{ github.actor }}
-          REGISTRY_PASSWORD: ${{ github.token }}
-        with:
-          image: ${{ steps.build_image.outputs.image }}
-          tags: ${{ steps.build_image.outputs.tags }}
-          registry: ${{ steps.registry_case.outputs.lowercase }}
-          username: ${{ env.REGISTRY_USER }}
-          password: ${{ env.REGISTRY_PASSWORD }}
-          extra-args: |
-            --disable-content-trust
-
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
-        if: github.event_name != 'pull_request' && github.ref == 'refs/heads/live'
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      # Sign container
-      - name: Sign container image
-        if: github.event_name != 'pull_request' && github.ref == 'refs/heads/live'
-        run: |
-          cosign sign -y --key env://COSIGN_PRIVATE_KEY ${{ steps.registry_case.outputs.lowercase }}/${{ steps.image_case.outputs.lowercase }}@${TAGS}
-        env:
-          TAGS: ${{ steps.push.outputs.digest }}
-          COSIGN_EXPERIMENTAL: false
-          COSIGN_PRIVATE_KEY: ${{ secrets.SIGNING_SECRET }}
+          ublue build -vv ./config/${{ matrix.recipe }}
 
       - name: Echo outputs
         if: github.event_name != 'pull_request' && github.ref == 'refs/heads/live'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,7 +30,7 @@ jobs:
     permissions:
       contents: read
     container:
-      image: registry.gitlab.com/wunker-bunker/ublue-cli:0.3.4-test-alpine
+      image: registry.gitlab.com/wunker-bunker/ublue-cli:alpine
     strategy:
       fail-fast: false
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,9 +55,9 @@ jobs:
         run: |
           curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 
-      - name: Install Ublue CLI tool
+      - name: Install BlueBuild tool
         run: |
-          cargo install ublue-rs --locked
+          cargo install blue-build --locked
 
       - name: Install Dependencies
         run: |
@@ -69,7 +69,7 @@ jobs:
           PR_EVENT_NUMBER: ${{ github.event.number }}
           REGISTRY_TOKEN: ${{ github.token }}
         run: |
-          ublue build --push -vv ./config/${{ matrix.recipe }}
+          bb build --push -vv ./config/${{ matrix.recipe }}
 
       - name: Echo outputs
         if: github.event_name != 'pull_request' && github.ref == 'refs/heads/live'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,6 +24,36 @@ env:
 # Only deploys the branch named "live". Ignores all other branches, to allow
 # having "development" branches without interfering with GHCR image uploads.
 jobs:
+  template:
+    name: Template Containerfile
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: read
+    container:
+      image: registry.gitlab.com/wunker-bunker/ublue-cli
+    strategy:
+      fail-fast: false
+
+      matrix:
+# !!!
+        # Add recipes for all the images you want to build here.
+        # Don't add module configuration files, you will get errors.
+        recipe:
+          - recipe.yml
+# !!!
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Run a Command
+        run: |
+          ublue template ./config/${{ matrix.recipe }} -o Containerfile
+
+      - name: Upload Artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: containerfile
+          path: Containerfile
   push-ghcr:
     name: Build and push image
     runs-on: ubuntu-22.04
@@ -43,6 +73,10 @@ jobs:
 # !!!
 
     steps:
+      - name: Download Artifact
+        uses: actions/download-artifact@v2
+        with:
+          name: containerfile
       - name: Maximize build space
         uses: AdityaGarg8/remove-unwanted-software@v1
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,8 +26,6 @@ jobs:
     runs-on: ubuntu-22.04
     permissions:
       contents: read
-    container:
-      image: registry.gitlab.com/wunker-bunker/ublue-cli:0.3.5-test-alpine
     strategy:
       fail-fast: false
 
@@ -40,11 +38,35 @@ jobs:
 # !!!
 
     steps:
+      - name: Maximize build space
+        uses: AdityaGarg8/remove-unwanted-software@v1
+        with:
+          remove-dotnet: 'true'
+          remove-android: 'true'
+          remove-haskell: 'true'
+
       - uses: actions/checkout@v2
 
-      - name: Template Containerfile
+      - uses: sigstore/cosign-installer@v3.3.0
+        if: github.event_name != 'pull_request' && github.ref == 'refs/heads/live'
+
+      - name: Install Cargo
+        run: |
+          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+
+      - name: Install Ublue CLI tool
+        run: |
+          cargo install --git https://gitlab.com/wunker-bunker/ublue-cli --branch github-support --locked
+
+      - name: Install Dependencies
+        run: |
+          apt-get install -y buildah skopeo
+
+      - name: Build Image
         env:
           COSIGN_PRIVATE_KEY: ${{ secrets.SIGNING_SECRET }}
+          GITHUB_EVENT_NUMBER: ${{ github.event.number }}
+          GITHUB_TOKEN: ${{ github.token }}
         run: |
           ublue build -vv ./config/${{ matrix.recipe }}
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,7 +48,6 @@ jobs:
       - uses: actions/checkout@v2
 
       - uses: sigstore/cosign-installer@v3.3.0
-        if: github.event_name != 'pull_request' && github.ref == 'refs/heads/live'
 
       - name: Install Cargo
         run: |
@@ -60,7 +59,7 @@ jobs:
 
       - name: Install Dependencies
         run: |
-          apt-get install -y buildah skopeo
+          sudo apt-get install -y buildah skopeo
 
       - name: Build Image
         env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,7 +30,7 @@ jobs:
     permissions:
       contents: read
     container:
-      image: registry.gitlab.com/wunker-bunker/ublue-cli
+      image: registry.gitlab.com/wunker-bunker/ublue-cli:0.3.4-test-alpine
     strategy:
       fail-fast: false
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ on: # https://docs.github.com/en/actions/using-workflows/events-that-trigger-wor
 # having "development" branches without interfering with GHCR image uploads.
 jobs:
   ublue-build:
-    name: Template Containerfile
+    name: Build and push image
     runs-on: ubuntu-22.04
     permissions:
       contents: read
@@ -47,7 +47,7 @@ jobs:
           remove-android: 'true'
           remove-haskell: 'true'
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - uses: sigstore/cosign-installer@v3.3.0
 
@@ -57,7 +57,7 @@ jobs:
 
       - name: Install Ublue CLI tool
         run: |
-          cargo install --git https://gitlab.com/wunker-bunker/ublue-cli --branch github-support --locked
+          cargo install ublue-rs --locked
 
       - name: Install Dependencies
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,6 +26,8 @@ jobs:
     runs-on: ubuntu-22.04
     permissions:
       contents: read
+      packages: write
+      id-token: write
     strategy:
       fail-fast: false
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -74,10 +74,6 @@ jobs:
 # !!!
 
     steps:
-      - name: Download Artifact
-        uses: actions/download-artifact@v2
-        with:
-          name: containerfile
       - name: Maximize build space
         uses: AdityaGarg8/remove-unwanted-software@v1
         with:
@@ -192,6 +188,11 @@ jobs:
         uses: ASzc/change-string-case-action@v6
         with:
           string: ${{ env.IMAGE_NAME }}
+
+      - name: Download Artifact
+        uses: actions/download-artifact@v2
+        with:
+          name: containerfile
 
       # Build image using Buildah action
       - name: Build Image

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -64,10 +64,10 @@ jobs:
       - name: Build Image
         env:
           COSIGN_PRIVATE_KEY: ${{ secrets.SIGNING_SECRET }}
-          GITHUB_EVENT_NUMBER: ${{ github.event.number }}
-          GITHUB_TOKEN: ${{ github.token }}
+          PR_EVENT_NUMBER: ${{ github.event.number }}
+          REGISTRY_TOKEN: ${{ github.token }}
         run: |
-          ublue build -vv ./config/${{ matrix.recipe }}
+          ublue build --push -vv ./config/${{ matrix.recipe }}
 
       - name: Echo outputs
         if: github.event_name != 'pull_request' && github.ref == 'refs/heads/live'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,6 +57,7 @@ jobs:
   push-ghcr:
     name: Build and push image
     runs-on: ubuntu-22.04
+    needs: template
     permissions:
       contents: read
       packages: write


### PR DESCRIPTION
I've been working on this tool for myself for months now and noticed that there was [interest](https://github.com/ublue-os/startingpoint/issues/156) in a tool like this. This is meant as a POC to the Ublue team for possibly using this as a "Recipe compiler".

The code for this tool is located [here in Gitlab](https://gitlab.com/wunker-bunker/ublue-cli) and [here on crates.io](https://crates.io/crates/ublue-rs) and my personal Ublue images repo which uses this tool is located [here](https://gitlab.com/wunker-bunker/wunker-os). 

I've gotten the tool to handle all the logic that the shell scripts for generating the image tags are doing for Gitlab CI (since I prefer Gitlab to Github), but future development work can all users to use the `build` command in Github if there is interest.