### PR TITLE
chore(recipe): Allow changing the public key used to verify base image

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -80,11 +80,13 @@ jobs:
           BASE_IMAGE=$(yq '.base-image' ./config/${{ matrix.recipe }})
           echo "BASE_IMAGE_URL=$BASE_IMAGE" >> $GITHUB_ENV
           echo "BASE_IMAGE_NAME=$(echo $BASE_IMAGE | sed 's/.*\/.*\///')" >> $GITHUB_ENV
+          echo "BASE_IMAGE_PUBKEY=$(yq '.base-image-pubkey' ./config/${{ matrix.recipe }})" >> $GITHUB_ENV
 
       - name: Verify base image
         uses: EyeCantCU/cosign-action/verify@v0.2.1
         with:
           containers: ${{ env.BASE_IMAGE_NAME }}:${{ env.IMAGE_MAJOR_VERSION }}
+          pubkey: ${{ env.BASE_IMAGE_PUBKEY }}
 
       - name: Get current version
         id: labels

--- a/config/recipe.yml
+++ b/config/recipe.yml
@@ -5,6 +5,8 @@ description: A starting point for further customization of uBlue images. Make yo
 
 # the base image to build on top of (FROM) and the version tag to use
 base-image: ghcr.io/ublue-os/silverblue-main
+# public key used by base image, default is key used by Universal Blue
+base-image-pubkey: 'https://raw.githubusercontent.com/ublue-os/main/main/cosign.pub'
 image-version: 39 # latest is also supported if you want new updates ASAP
 
 # module configuration, executed in order


### PR DESCRIPTION
Adds an entry to `recipe.yml` enabling users to define their own public keys for the 'verify' action